### PR TITLE
Fix crash on unset devices

### DIFF
--- a/dtg_domoticz.lua
+++ b/dtg_domoticz.lua
@@ -122,6 +122,12 @@ function device_list_names_idxs(DeviceType)
   result = decoded_response['result']
   devices = {}
   devicesproperties = {}
+  
+  if type(result) ~= 'table' then
+        print_to_log(0, 'No devices found for type "'.. DeviceType ..'"')
+        return devices, devicesproperties
+  end
+  
   for i = 1, #result do
     record = result[i]
     if type(record) == "table" then


### PR DESCRIPTION
If device list returns a nil value, returns empty tables 
Resolves issue: https://github.com/steps39/dtgbot/issues/2
